### PR TITLE
Manage case when multiple jquery object get passed to the constructor

### DIFF
--- a/js/basic-jquery-slider.js
+++ b/js/basic-jquery-slider.js
@@ -17,7 +17,7 @@
  * 
  */ (function ($) {
     $.fn.bjqs = function (options) {
-	   return this.each(function() {
+		return this.each(function() {
         var settings = {},
             defaults = {
 				// Width + Height used to ensure consistency
@@ -379,6 +379,6 @@
 
             }
 
-       });
+        });
     }
 })(jQuery);


### PR DESCRIPTION
Hi,

I've added support for multiple sliders instantiated at once on bjqs.

An example use case is if a user target all `.slider` element and pass them to the `bjqs` plugin

``` javascript
$('.slider') // There may be 10 `.slider` in the page
    .bjqs({ /* options */ });
```

Right now, user must define each slider separately (mostly using ids) and cannot instantiate more than one at a time.

So, this will be pretty neat for a lot of use cases.

---

On an other note, you should normalize the line ending of your file ( (like this)[https://github.com/h5bp/html5-boilerplate/blob/master/.gitattributes] ). This would be most appreciate to people wanting to contribute on your plugin !

And you could also normalize your usage of tabs/space (right now, both are used). May I suggest going on tabs ?
