### PR TITLE
If only one slide is available, disable automatic animation.

### DIFF
--- a/js/bjqs-1.3.js
+++ b/js/bjqs-1.3.js
@@ -144,6 +144,9 @@
                     conf_slide();
                 }
 
+            } else {
+                // Stop automatic animation, because we only have one slide! 
+                settings.automatic = false;
             }
 
             if(settings.usecaptions){


### PR DESCRIPTION
[BJQS] B: If only one slide is available, disable automatic animation, this because otherwise you will see the image 'flicker' every x seconds.
