### PR TITLE
Html captions not being wrapper properly

### DIFF
--- a/js/bjqs-1.3.js
+++ b/js/bjqs-1.3.js
@@ -560,7 +560,7 @@
         var conf_captions = function() {
 
             $.each($slides, function (key, slide) {
-
+				var captionContainer;
                 var caption = $(slide).children('img:first-child').attr('title');
 
                 // Account for images wrapped in links
@@ -569,7 +569,8 @@
                 }
 
                 if (caption) {
-                    caption = $('<p class="bjqs-caption">' + caption + '</p>');
+					captionContainer = $('<p />').addClass('bjqs-caption');
+                    caption = captionContainer.html(caption);
                     caption.appendTo($(slide));
                 }
 


### PR DESCRIPTION
The way the current html captions were being set would results in duplicate 'p' tags. This commit fixes that issue.
