### PR TITLE
Update li width on load

### DIFF
--- a/js/bjqs-1.3.js
+++ b/js/bjqs-1.3.js
@@ -264,7 +264,8 @@
                 if(responsive.width < settings.width){
 
                     $slides.css({
-                        'height'        : responsive.height
+                        'height'        : responsive.height,
+                        'width'         : responsive.width
                     });
                     $slides.children('img').css({
                         'height'        : responsive.height


### PR DESCRIPTION
This causes the slides to be out of alignment when you load up on a different sized device. This line saved all my hair from being pulled out.
