### PR TITLE
Responsive slider not functioning correctly on page load

### DIFF
--- a/js/bjqs-1.3.js
+++ b/js/bjqs-1.3.js
@@ -251,6 +251,10 @@
                     'height'        : settings.height,
                     'width'         : settings.width
                 });
+                $slides.children('a').children('img').css({
+                    'height'        : settings.height,
+                    'width'         : settings.width
+                });
                 $slider.css({
                     'height'        : settings.height,
                     'width'         : settings.width * settings.slidecount
@@ -264,13 +268,20 @@
                 if(responsive.width < settings.width){
 
                     $slides.css({
-                        'height'        : responsive.height
+                        'height'        : responsive.height,
+                        'width'         : responsive.width
                     });
                     $slides.children('img').css({
-                        'height'        : responsive.height
+                        'height'        : responsive.height,
+                        'width'         : responsive.width
+                    });
+                    $slides.children('a').children('img').css({
+                        'height'        : responsive.height,
+                        'width'         : responsive.width
                     });
                     $slider.css({
-                        'height'        : responsive.height
+                        'height'        : responsive.height,
+                        'width'         : responsive.width * settings.slidecount
                     });
                     $wrapper.css({
                         'height'        : responsive.height
@@ -290,6 +301,10 @@
                         'width'         : responsive.width
                     });
                     $slides.children('img').css({
+                        'height'        : responsive.height,
+                        'width'         : responsive.width
+                    });
+                    $slides.children('a').children('img').css({
                         'height'        : responsive.height,
                         'width'         : responsive.width
                     });


### PR DESCRIPTION
The responsive slider with "animtype : slide" does not load correctly if the slider is smaller than the set dimensions. It does correct itself on page resize, but does nothing if the initial page is not resized. Additionally, images inside of anchor tags are not affected at all by resizing statements. I believe this functionality should be implemented throughout the entire plugin since slideshows are almost always an image linking to another location rather than just an image. My changes only affect nested anchor-images in the slider type "animtype : slide".